### PR TITLE
docs: add references + links to component docs

### DIFF
--- a/src/components/date.rs
+++ b/src/components/date.rs
@@ -28,7 +28,10 @@ pub fn parse_date(s: &str) -> Option<NaiveDate> {
 	parse_format(s, parse_date_component)
 }
 
-/// Low-level function for parsing an individual date component
+/// Low-level function for parsing an individual date component at a given position
+///
+/// This follows the rules for [parsing a date component][whatwg-html-parse],
+/// per [WHATWG HTML Standard § 2.3.5.2 Dates][whatwg-html-dates].
 ///
 /// > **Note**:
 /// > This function exposes a lower-level API than [`parse_date`]. More than likely,
@@ -44,6 +47,9 @@ pub fn parse_date(s: &str) -> Option<NaiveDate> {
 ///
 /// assert_eq!(date, NaiveDate::from_ymd_opt(2011, 11, 18));
 /// ```
+///
+/// [whatwg-html-dates]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#dates
+/// [whatwg-html-parse]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#parse-a-date-component
 pub fn parse_date_component(s: &str, position: &mut usize) -> Option<NaiveDate> {
 	let year_month = parse_month_component(s, position)?;
 	let year = year_month.year;

--- a/src/components/month.rs
+++ b/src/components/month.rs
@@ -100,7 +100,10 @@ pub fn parse_month(s: &str) -> Option<YearMonth> {
 	parse_format(s, parse_month_component)
 }
 
-/// Low-level function for parsing an individual month component
+/// Low-level function for parsing an individual month component at a given position
+///
+/// This follows the rules for [parsing a month component][whatwg-html-parse]
+/// per [WHATWG HTML Standard § 2.3.5.1 Months][whatwg-html-months].
 ///
 /// > **Note**:
 /// > This function exposes a lower-level API than [`parse_month`]. More than likely,
@@ -115,6 +118,9 @@ pub fn parse_month(s: &str) -> Option<YearMonth> {
 ///
 /// assert_eq!(date, YearMonth::new_opt(2011, 11));
 /// ```
+///
+/// [whatwg-html-months]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#months
+/// [whatwg-html-parse]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#parse-a-month-component
 pub fn parse_month_component(s: &str, position: &mut usize) -> Option<YearMonth> {
 	let parsed_year = collect_ascii_digits(s, position);
 	if parsed_year.len() < 4 {

--- a/src/components/time.rs
+++ b/src/components/time.rs
@@ -7,7 +7,7 @@ use whatwg_infra::collect_codepoints;
 /// Parse a specific time containing an hour, minute, and optionally a second,
 /// and a fraction of a second
 ///
-/// This follows the rules for [parsing a month string][whatwg-html-parse]
+/// This follows the rules for [parsing a time string][whatwg-html-parse]
 /// per [WHATWG HTML Standard § 2.3.5.4 Times][whatwg-html-time].
 ///
 /// # Examples
@@ -26,13 +26,16 @@ use whatwg_infra::collect_codepoints;
 /// ```
 ///
 /// [whatwg-html-time]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#times
-/// [whatwg-html-parse]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#parse-a-month-string
+/// [whatwg-html-parse]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#parse-a-time-string
 #[inline]
 pub fn parse_time(s: &str) -> Option<NaiveTime> {
 	parse_format(s, parse_time_component)
 }
 
-/// Low-level function for parsing an individual time component
+/// Low-level function for parsing an individual time component at a given position
+///
+/// This follows the rules for [parsing a time component][whatwg-html-parse]
+/// per [WHATWG HTML Standard § 2.3.5.4 Times][whatwg-html-time].
 ///
 /// > **Note**:
 /// > This function exposes a lower-level API than [`parse_time`]. More than likely,
@@ -48,6 +51,9 @@ pub fn parse_time(s: &str) -> Option<NaiveTime> {
 ///
 /// assert_eq!(date, NaiveTime::from_hms_opt(14, 59, 0));
 /// ```
+///
+/// [whatwg-html-time]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#times
+/// [whatwg-html-parse]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#parse-a-time-component
 pub fn parse_time_component(s: &str, position: &mut usize) -> Option<NaiveTime> {
 	let parsed_hour = collect_ascii_digits(s, position);
 	if parsed_hour.len() != 2 {

--- a/src/components/timezone_offset.rs
+++ b/src/components/timezone_offset.rs
@@ -98,7 +98,7 @@ impl TryFrom<char> for TimeZoneSign {
 /// Parse a time-zone offset, with a signed number of hours and minutes
 ///
 /// This follows the rules for [parsing a time-zone offset string][whatwg-html-parse]
-/// per [WHATWG HTML Standard § 2.3.5.6 Time zoness][whatwg-html-tzoffset].
+/// per [WHATWG HTML Standard § 2.3.5.6 Time zones][whatwg-html-tzoffset].
 ///
 /// # Examples
 /// ```
@@ -120,6 +120,10 @@ pub fn parse_timezone_offset(s: &str) -> Option<TimeZoneOffset> {
 }
 
 /// Low-level function for parsing an individual timezone offset component
+/// at a given position
+///
+/// This follows the rules for [parsing a time-zone offset component][whatwg-html-parse]
+/// per [WHATWG HTML Standard § 2.3.5.6 Time zones][whatwg-html-tzoffset].
 ///
 /// > **Note**:
 /// > This function exposes a lower-level API than [`parse_timezone_offset`].
@@ -134,6 +138,9 @@ pub fn parse_timezone_offset(s: &str) -> Option<TimeZoneOffset> {
 ///
 /// assert_eq!(date, TimeZoneOffset::new_opt(-7, 0));
 /// ```
+///
+/// [whatwg-html-tzoffset]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#time-zones
+/// [whatwg-html-parse]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#parse-a-time-zone-offset-component
 pub fn parse_timezone_offset_component(s: &str, position: &mut usize) -> Option<TimeZoneOffset> {
 	let char_at = s.chars().nth(*position);
 

--- a/src/components/yearless_date.rs
+++ b/src/components/yearless_date.rs
@@ -115,6 +115,10 @@ pub fn parse_yearless_date(s: &str) -> Option<YearlessDate> {
 }
 
 /// Low-level function for parsing an individual yearless date component
+/// at a given position
+///
+/// This follows the rules for [parsing a yearless date component][whatwg-html-parse]
+/// per [WHATWG HTML Standard § 2.3.5.3 Yearless dates][whatwg-html-yearless].
 ///
 /// > **Note**:
 /// > This function exposes a lower-level API than [`parse_yearless_date`].
@@ -129,6 +133,9 @@ pub fn parse_yearless_date(s: &str) -> Option<YearlessDate> {
 ///
 /// assert_eq!(date, YearlessDate::new_opt(11, 18));
 /// ```
+///
+/// [whatwg-html-yearless]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#yearless-dates
+/// [whatwg-html-parse]: https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#parse-a-yearless-date-component
 pub fn parse_yearless_date_component(s: &str, position: &mut usize) -> Option<YearlessDate> {
 	let collected = collect_codepoints(s, position, |c| c == TOKEN_HYPHEN);
 	if !matches!(collected.len(), 0 | 2) {


### PR DESCRIPTION
 - fix copypaste error/typo in `parse_time()` and `parse_timezone_offset()` docs
 - add links to sections and definitions from the WHATWG HTML Standard